### PR TITLE
use 'plugin-load-add' instead of 'plugin-load' in default_plugins.cnf

### DIFF
--- a/mariadb-100/default_plugins.cnf
+++ b/mariadb-100/default_plugins.cnf
@@ -1,4 +1,4 @@
 [server]
-#plugin-load=blackhole=ha_blackhole.so
-#plugin-load=federated=ha_federated.so
-#plugin-load=archive=ha_archive.so
+#plugin-load-add=blackhole=ha_blackhole.so
+#plugin-load-add=federated=ha_federated.so
+#plugin-load-add=archive=ha_archive.so

--- a/mariadb-101/default_plugins.cnf
+++ b/mariadb-101/default_plugins.cnf
@@ -1,4 +1,4 @@
 [server]
-#plugin-load=blackhole=ha_blackhole.so
-#plugin-load=federated=ha_federated.so
-#plugin-load=archive=ha_archive.so
+#plugin-load-add=blackhole=ha_blackhole.so
+#plugin-load-add=federated=ha_federated.so
+#plugin-load-add=archive=ha_archive.so

--- a/mariadb-55/default_plugins.cnf
+++ b/mariadb-55/default_plugins.cnf
@@ -1,4 +1,2 @@
 [server]
-plugin-load=blackhole=ha_blackhole.so
-plugin-load=federated=ha_federated.so
-plugin-load=archive=ha_archive.so
+plugin-load=blackhole=ha_blackhole.so;federated=ha_federated.so;archive=ha_archive.so

--- a/mysql-community-server-56/default_plugins.cnf
+++ b/mysql-community-server-56/default_plugins.cnf
@@ -1,4 +1,4 @@
 [server]
-#plugin-load=blackhole=ha_blackhole.so
-#plugin-load=federated=ha_federated.so
-#plugin-load=archive=ha_archive.so
+#plugin-load-add=blackhole=ha_blackhole.so
+#plugin-load-add=federated=ha_federated.so
+#plugin-load-add=archive=ha_archive.so

--- a/mysql-community-server-57/default_plugins.cnf
+++ b/mysql-community-server-57/default_plugins.cnf
@@ -1,4 +1,4 @@
 [server]
-plugin-load=blackhole=ha_blackhole.so
-plugin-load=federated=ha_federated.so
-plugin-load=archive=ha_archive.so
+plugin-load-add=blackhole=ha_blackhole.so
+plugin-load-add=federated=ha_federated.so
+plugin-load-add=archive=ha_archive.so


### PR DESCRIPTION
default_plugins.cnf had multiple 'plugin-load' options which caused
that only last plugin was actually loaded ('plugin-load' overrides
the previous 'plugin-load'). 'plugin-load-add' is now used for
MariaDB >= 10.0.1 and MySQL >= 5.6.3. 'plugin-load' with
semicolon-separated list of plugins is used for MariaDB-55.