### PR TITLE
Disable Performance Schema for mysql-community-server

### DIFF
--- a/mysql-community-server-56/01_performance_schema_off.diff
+++ b/mysql-community-server-56/01_performance_schema_off.diff
@@ -1,0 +1,15 @@
+diff --git a/common/my.ini b/common/my.ini
+index 91087c7..616f0de 100644
+--- a/common/my.ini
++++ b/common/my.ini
+@@ -55,6 +55,10 @@ server-id	= 1
+ # sort_buffer_size = 2M
+ # read_rnd_buffer_size = 2M 
+ 
++# The following option disables Performance Schema in order to decrease
++# MySQL memory usage.
++performance_schema=OFF
++
+ sql_mode=NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES
+ 
+ [mysqld_multi]

--- a/mysql-community-server-57/01_performance_schema_off.diff
+++ b/mysql-community-server-57/01_performance_schema_off.diff
@@ -1,0 +1,1 @@
+../mysql-community-server-56/01_performance_schema_off.diff


### PR DESCRIPTION
Add an additional patch to the project (01_performance_schema_off.diff) to
disable Performance Schema (performance_schema=OFF in my.cnf configuration file).

Since MySQL 5.6.6 upstream enabled Performance Schema by default which results in
increased memory usage. The added option disable Performance Schema again in order
to decrease MySQL memory usage. Only MySQL is affected by this issue as MariaDB
has performance_schema=OFF by default [bnc#852477]