### PR TITLE
Add mariadb patches to avoid testcase timeout

### DIFF
--- a/mariadb-100/series
+++ b/mariadb-100/series
@@ -13,3 +13,4 @@ mariadb-10.0.15-logrotate-su.patch
 mariadb-10.0.15-covscan-signexpr.patch
 mariadb-10.0.10-string-overflow.patch
 mariadb-10.0.20-tabxml-bufferoverflowstrncat.patch
+mariadb-10.0.21-mysql-test_innodb_simulate_comp_failures.patch

--- a/mariadb-101/series
+++ b/mariadb-101/series
@@ -12,3 +12,4 @@ mariadb-10.1.1-header_files_const_warnings.patch
 mariadb-10.0.15-logrotate-su.patch
 mariadb-10.1.4-fortify-and-O.patch
 mariadb-10.1.6-tabxml-bufferoverflowstrncat.patch
+mariadb-10.1.6-mysql-test_innodb_simulate_comp_failures.patch

--- a/patches/mysql-patches/mariadb-10.0.21-mysql-test_innodb_simulate_comp_failures.patch
+++ b/patches/mysql-patches/mariadb-10.0.21-mysql-test_innodb_simulate_comp_failures.patch
@@ -1,0 +1,26 @@
+PATCH-P1-FIX-UPSTREAM: Reduce the number of rounds and operations to avoid testcase timeout.
+BUGS: bnc#937343, MDEV-8443
+
+Maintainer: Kristyna Streitova <kstreitova@suse.com>
+
+--- a/mysql-test/suite/innodb/r/innodb_simulate_comp_failures.result	
++++ a/mysql-test/suite/innodb/r/innodb_simulate_comp_failures.result	
+@@ -5,4 +5,4 @@ CREATE TABLE t1(id INT AUTO_INCREMENT PRIMARY KEY, msg VARCHAR(255), KEY msg_i(m
+ SET GLOBAL innodb_simulate_comp_failures = 25;
+ SELECT COUNT(*) FROM t1;
+ COUNT(*)
+-10000
++2000
+--- a/mysql-test/suite/innodb/t/innodb_simulate_comp_failures.test	
++++ a/mysql-test/suite/innodb/t/innodb_simulate_comp_failures.test	
+@@ -1,8 +1,8 @@ 
+ --source include/big_test.inc
+ # test takes too long with valgrind
+ --source include/not_valgrind.inc
+---let $num_inserts = 10000
+---let $num_ops = 10000
++--let $num_inserts = 2000
++--let $num_ops = 4000
+ --source suite/innodb/include/innodb_simulate_comp_failures.inc
+ # clean exit
+ --exit

--- a/patches/mysql-patches/mariadb-10.1.6-mysql-test_innodb_simulate_comp_failures.patch
+++ b/patches/mysql-patches/mariadb-10.1.6-mysql-test_innodb_simulate_comp_failures.patch
@@ -1,0 +1,26 @@
+PATCH-P1-FIX-UPSTREAM: Reduce the number of rounds and operations to avoid testcase timeout.
+BUGS: bnc#937343, MDEV-8443
+
+Maintainer: Kristyna Streitova <kstreitova@suse.com>
+
+--- a/mysql-test/suite/innodb/r/innodb_simulate_comp_failures.result	
++++ a/mysql-test/suite/innodb/r/innodb_simulate_comp_failures.result	
+@@ -5,4 +5,4 @@ CREATE TABLE t1(id INT AUTO_INCREMENT PRIMARY KEY, msg VARCHAR(255), KEY msg_i(m
+ SET GLOBAL innodb_simulate_comp_failures = 25;
+ SELECT COUNT(*) FROM t1;
+ COUNT(*)
+-100000
++2000
+--- a/mysql-test/suite/innodb/t/innodb_simulate_comp_failures.test	
++++ a/mysql-test/suite/innodb/t/innodb_simulate_comp_failures.test	
+@@ -1,8 +1,8 @@ 
+ --source include/big_test.inc
+ # test takes too long with valgrind
+ --source include/not_valgrind.inc
+---let $num_inserts = 100000
+---let $num_ops = 30000
++--let $num_inserts = 2000
++--let $num_ops = 4000
+ --source suite/innodb/include/innodb_simulate_comp_failures.inc
+ # clean exit
+ --exit


### PR DESCRIPTION
mariadb-100
- add mariadb-10.0.21-mysql-test_innodb_simulate_comp_failures.patch to
  reduce the number of rounds and operations to avoid testcase timeout
  [bnc#937343]

mariadb-101
- add mariadb-10.1.6-mysql-test_innodb_simulate_comp_failures.patch to
  reduce the number of rounds and operations to avoid testcase timeout
  [bnc#937343]