### PR TITLE
add patch to fix main.bootstrap test

### DIFF
--- a/mariadb-100/series
+++ b/mariadb-100/series
@@ -14,3 +14,4 @@ mariadb-10.0.15-covscan-signexpr.patch
 mariadb-10.0.10-string-overflow.patch
 mariadb-10.0.20-tabxml-bufferoverflowstrncat.patch
 mariadb-10.0.21-mysql-test_innodb_simulate_comp_failures.patch
+mariadb-10.0.21-mysql-test_main_bootstrap.patch

--- a/mariadb-101/series
+++ b/mariadb-101/series
@@ -13,3 +13,4 @@ mariadb-10.0.15-logrotate-su.patch
 mariadb-10.1.4-fortify-and-O.patch
 mariadb-10.1.6-tabxml-bufferoverflowstrncat.patch
 mariadb-10.1.6-mysql-test_innodb_simulate_comp_failures.patch
+mariadb-10.0.21-mysql-test_main_bootstrap.patch

--- a/patches/mysql-patches/mariadb-10.0.21-mysql-test_main_bootstrap.patch
+++ b/patches/mysql-patches/mariadb-10.0.21-mysql-test_main_bootstrap.patch
@@ -1,0 +1,19 @@
+PATCH-P1-FIX-UPSTREAM: Change test result default charset to utf8 
+BUGS: bnc#937787, MDEV-8486
+
+Default value of the 'DEFAULT_CHARSET' option is 'latin1', but we use
+'utf8'. Therefore the test result has to be adjusted accordingly.
+
+Maintainer: Kristyna Streitova <kstreitova@suse.com>
+
+--- mariadb-10.0.20/mysql-test/r/bootstrap.result	
++++ mariadb-10.0.20/mysql-test/r/bootstrap.result	
+@@ -20,7 +20,7 @@ show create table t1;
+ Table	Create Table
+ t1	CREATE TABLE `t1` (
+   `a` int(11) DEFAULT NULL
+-) ENGINE=MyISAM DEFAULT CHARSET=latin1
++) ENGINE=MyISAM DEFAULT CHARSET=utf8
+ drop table t1;
+ select * from mysql.plugin;
+ name	dl


### PR DESCRIPTION
mariadb-100 and mariadb 101:
- add mariadb-10.0.21-mysql-test_main_bootstrap.patch that fix
  main.bootstrap test (change test result default charset to utf8)
  [bnc#937787]
