### PR TITLE
Update MySQL to 5.6.30

### DIFF
--- a/mysql-community-server-56/config.yaml
+++ b/mysql-community-server-56/config.yaml
@@ -4,7 +4,7 @@ display-name:     "MySQL Community Server"
 preferred:        0
 extra_provides:   mysql-community-server_56
 builtin_plugins:  partition,csv,heap,myisam,innobase
-pkg-version:      "5.6.28"
+pkg-version:      "5.6.30"
 url:              "http://www.mysql.com"
 source:           "https://dev.mysql.com/get/Downloads/MySQL-5.6/mysql-%{version}.tar.gz"
 src-dir:          "mysql-%{version}"


### PR DESCRIPTION
[mysql-community-server-56]

- update to 5.6.30
  * changes
    http://dev.mysql.com/doc/relnotes/mysql/5.6/en/news-5-6-30.html
    http://dev.mysql.com/doc/relnotes/mysql/5.6/en/news-5-6-29.html
  * fixed CVEs:
    CVE-2016-0705, CVE-2016-0639, CVE-2015-3194, CVE-2016-0640,
    CVE-2016-2047, CVE-2016-0644, CVE-2016-0646, CVE-2016-0647,
    CVE-2016-0648, CVE-2016-0649, CVE-2016-0650, CVE-2016-0665,
    CVE-2016-0666, CVE-2016-0641, CVE-2016-0642, CVE-2016-0655,
    CVE-2016-0661, CVE-2016-0668, CVE-2016-0643
  * fix [bnc#962779], [bnc#959724]