### PR TITLE
Update MariaDB to 10.1.20

### DIFF
--- a/mariadb-101/config.yaml
+++ b/mariadb-101/config.yaml
@@ -6,7 +6,7 @@ build_readline:   1
 build_extras:     1
 extra_provides:   mariadb_101
 builtin_plugins:  partition,csv,heap,aria,pbxt,myisam,myisammrg,xtradb
-pkg-version:      "10.1.19"
+pkg-version:      "10.1.20"
 url:              "https://www.mariadb.org"
 source:           "https://downloads.mariadb.org/f/mariadb-%{version}/source/mariadb-%{version}.tar.gz"
 src-dir:          "mariadb-%{version}"


### PR DESCRIPTION
- update to MariaDB 10.1.20
  * notable changes:
    * XtraDB updated to 5.6.34-79.1
    * TokuDB updated to 5.6.34-79.1
    * HeidiSQL updated to 9.4
    * The limit for the table_open_cache system variable has been increased to 1024K
    * Galera wsrep library updated to 25.3.19
  * release notes and changelog:
     * https://mariadb.com/kb/en/mariadb/mariadb-10120-release-notes/
     * https://mariadb.com/kb/en/mariadb/mariadb-10120-changelog/