### PR TITLE
Update MariaDB to 10.1.21 and Static include TokuDB

### DIFF
--- a/common/mysql.spec.in
+++ b/common/mysql.spec.in
@@ -1,7 +1,7 @@
 #
 # spec file for package {{pkg-name}}
 #
-# Copyright (c) 2016 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2017 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -359,7 +359,9 @@ EXTRA_FLAGS="-Wno-unused-but-set-variable -fno-strict-aliasing -Wno-unused-param
 EXTRA_FLAGS="${EXTRA_FLAGS} -Wno-error"
 export CFLAGS="%{optflags} -DOPENSSL_LOAD_CONF -DPIC -fPIC -DFORCE_INIT_OF_VARS $EXTRA_FLAGS"
 export CXXFLAGS="$CFLAGS -felide-constructors"
-%cmake -DWITH_SSL=system                                             \
+%cmake  -LA                                                          \
+        -DPLUGIN_TOKUDB=STATIC                                       \
+        -DWITH_SSL=system                                            \
         -DWITH_ASAN=OFF                                              \
         -DWITH_LIBWRAP=ON                                            \
         -DENABLED_PROFILING=ON                                       \

--- a/mariadb-101/config.yaml
+++ b/mariadb-101/config.yaml
@@ -6,7 +6,7 @@ build_readline:   1
 build_extras:     1
 extra_provides:   mariadb_101
 builtin_plugins:  partition,csv,heap,aria,pbxt,myisam,myisammrg,xtradb
-pkg-version:      "10.1.20"
+pkg-version:      "10.1.21"
 url:              "https://www.mariadb.org"
 source:           "https://downloads.mariadb.org/f/mariadb-%{version}/source/mariadb-%{version}.tar.gz"
 src-dir:          "mariadb-%{version}"

--- a/patches/mysql-patches/mariadb-10.1.4-group.patch
+++ b/patches/mysql-patches/mariadb-10.1.4-group.patch
@@ -9,7 +9,7 @@ Index: scripts/mysqld_safe.sh
 ===================================================================
 --- scripts/mysqld_safe.sh.orig
 +++ scripts/mysqld_safe.sh
-@@ -28,6 +28,7 @@ logging=init
+@@ -29,6 +29,7 @@ logging=init
  want_syslog=0
  syslog_tag=
  user='@MYSQLD_USER@'
@@ -17,7 +17,7 @@ Index: scripts/mysqld_safe.sh
  pid_file=
  err_log=
  err_log_base=
-@@ -289,6 +290,7 @@ parse_arguments() {
+@@ -308,6 +309,7 @@ parse_arguments() {
        --pid[-_]file=*) pid_file="$val" ;;
        --plugin[-_]dir=*) PLUGIN_DIR="$val" ;;
        --user=*) user="$val"; SET_USER=1 ;;
@@ -25,26 +25,15 @@ Index: scripts/mysqld_safe.sh
        --log[-_]basename=*|--hostname=*|--loose[-_]log[-_]basename=*)
          pid_file="$val.pid";
  	err_log_base="$val";
-@@ -748,11 +750,17 @@ then
+@@ -737,6 +739,7 @@ then
    if test "$user" != "root" -o $SET_USER = 1
    then
      USER_OPTION="--user=$user"
 +    GROUP_OPTION="--group=$group"
    fi
-   # Change the err log to the right user, if it is in use
-   if [ $want_syslog -eq 0 ]; then
-     touch "$err_log"
--    chown $user "$err_log"
-+    if [ "$user" -a "$group" ]; then
-+      chown $user:$group $err_log
-+    else
-+      [ "$user" ] && chown $user $err_log
-+      [ "$group" ] && chgrp $group $err_log
-+    fi
-   fi
    if test -n "$open_files"
    then
-@@ -775,7 +783,12 @@ then
+@@ -759,7 +762,12 @@ then
      log_error "Fatal error Can't create database directory '$mysql_unix_port'"
      exit 1
    fi
@@ -70,7 +59,7 @@ Index: scripts/mysql_install_db.sh
  
  force=0
  in_rpm=0
-@@ -71,6 +72,11 @@ Usage: $0 [OPTIONS]
+@@ -88,6 +89,11 @@ Usage: $0 [OPTIONS]
                         user.  You must be root to use this option.  By default
                         mysqld runs using your current login name and files and
                         directories that it creates will be owned by you.
@@ -82,7 +71,7 @@ Index: scripts/mysql_install_db.sh
  
  All other options are passed to the mysqld program
  
-@@ -118,11 +124,11 @@ parse_arguments()
+@@ -135,11 +141,11 @@ parse_arguments()
        --builddir=*) builddir=`parse_arg "$arg"` ;;
        --srcdir=*)  srcdir=`parse_arg "$arg"` ;;
        --ldata=*|--datadir=*|--data=*) ldata=`parse_arg "$arg"` ;;
@@ -96,7 +85,7 @@ Index: scripts/mysql_install_db.sh
        --skip-name-resolve) ip_only=1 ;;
        --verbose) verbose=1 ;; # Obsolete
        --rpm) in_rpm=1 ;;
-@@ -392,7 +398,12 @@ do
+@@ -420,7 +426,12 @@ do
    fi
    if test -n "$user"
    then
@@ -110,7 +99,7 @@ Index: scripts/mysql_install_db.sh
      if test $? -ne 0
      then
        echo "Cannot change ownership of the database directories to the '$user'"
-@@ -407,6 +418,11 @@ then
+@@ -435,6 +446,11 @@ then
    args="$args --user=$user"
  fi
  


### PR DESCRIPTION
I'm fixed group patch.
Rechecked removed section "# Change the err log to the right user, if it is in use" please.
TokuDB is just as important engine like InnoDB, and must be enabled statically, the more of it is not even in /etc/my.cnf.d/default_plugins.cnf.