### PR TITLE
Update systemd requirements

### DIFF
--- a/common/mysql.spec.in
+++ b/common/mysql.spec.in
@@ -99,10 +99,7 @@ BuildRequires:  sqlite
 BuildRequires:  tcpd-devel
 BuildRequires:  time
 BuildRequires:  zlib-devel
-# pkgconfig(systemd) on most versions is in systemd main pkg, remove
-# after oldest supported is Leap 43
-BuildRequires:  systemd
-BuildRequires:  systemd-devel
+BuildRequires:  pkgconfig(systemd)
 # required by rcmysql
 Requires:       %{name}-client
 Requires:       %{name}-errormessages = %{version}


### PR DESCRIPTION
Requiring pkgconfig(systemd) seems to be safe after recent systemd maintenance updates - this would resolve issue #59