### PR TITLE
Load plugin for TokuDB engine

### DIFF
--- a/mariadb-100/default_plugins.cnf
+++ b/mariadb-100/default_plugins.cnf
@@ -1,4 +1,5 @@
 [server]
+plugin-load-add=tokudb=ha_tokudb.so
 #plugin-load-add=blackhole=ha_blackhole.so
 #plugin-load-add=federated=ha_federated.so
 #plugin-load-add=archive=ha_archive.so

--- a/mariadb-101/default_plugins.cnf
+++ b/mariadb-101/default_plugins.cnf
@@ -1,4 +1,5 @@
 [server]
+plugin-load-add=tokudb=ha_tokudb.so
 #plugin-load-add=blackhole=ha_blackhole.so
 #plugin-load-add=federated=ha_federated.so
 #plugin-load-add=archive=ha_archive.so

--- a/mariadb-102/default_plugins.cnf
+++ b/mariadb-102/default_plugins.cnf
@@ -1,4 +1,5 @@
 [server]
+plugin-load-add=tokudb=ha_tokudb.so
 #plugin-load-add=blackhole=ha_blackhole.so
 #plugin-load-add=federated=ha_federated.so
 #plugin-load-add=archive=ha_archive.so

--- a/mysql-community-server-56/default_plugins.cnf
+++ b/mysql-community-server-56/default_plugins.cnf
@@ -1,4 +1,5 @@
 [server]
+plugin-load-add=tokudb=ha_tokudb.so
 #plugin-load-add=blackhole=ha_blackhole.so
 #plugin-load-add=federated=ha_federated.so
 #plugin-load-add=archive=ha_archive.so

--- a/mysql-community-server-57/default_plugins.cnf
+++ b/mysql-community-server-57/default_plugins.cnf
@@ -1,4 +1,5 @@
 [server]
+plugin-load-add=tokudb=ha_tokudb.so
 plugin-load-add=blackhole=ha_blackhole.so
 plugin-load-add=federated=ha_federated.so
 plugin-load-add=archive=ha_archive.so


### PR DESCRIPTION
TokuDB is just as important engine like InnoDB, and must be load by default.