### PR TITLE
build-obs-package: Trust keys from the OBS projects

### DIFF
--- a/build-obs-package.sh
+++ b/build-obs-package.sh
@@ -19,7 +19,7 @@ FAILED=0
 build_package() {
     echo -n "Test build ${2}/${1}: "
     pushd "${WORKDIR}/"*"/${1}" > /dev/null
-    osc build --cpio-bulk-download --download-api-only ${2} &> /dev/null || {
+    osc build --trust-all-projects --cpio-bulk-download --download-api-only ${2} &> /dev/null || {
         echo -e "${RED}FAILED${NC}"
         if [[ -z $3 ]]; then
             FAILED=1


### PR DESCRIPTION
If no previous build was attempted, 'osc build' is stuck waiting for
user input to accept the OBS project keys before building the packages.
However, as stdout and stderr are being redirected to /dev/null, the
user is not aware of that rendering the whole operation suboptimal. So,
in order to facilitate the automated builds, we accept keys from the
OBS projects without asking.