### PR TITLE
common: Add ability to pass extra arguments to the mysqld process

### DIFF
--- a/common/mysql-systemd-helper
+++ b/common/mysql-systemd-helper
@@ -52,8 +52,9 @@ read_config() {
 mysql_install() {
 	if [[ ! -d "$datadir/mysql" ]]; then
 		echo "Creating MySQL privilege database... "
-		mysql_install_db --user="$mysql_daemon_user" --datadir="$datadir" || \
-		die "Creation of MySQL databse in $datadir failed"
+		mysql_install_db --user="$mysql_daemon_user" --datadir="$datadir" \
+			"$MYSQLD_EXTRA_INSTALL_OPTS" || \
+			die "Creation of MySQL databse in $datadir failed"
 		echo -n "$MYSQLVER" > "$datadir"/mysql_upgrade_info
 	fi
 }
@@ -104,7 +105,8 @@ mysql_upgrade() {
 			$ignore_db_dir \
 			--log-error="$protected/log_upgrade_run" \
 			--socket="$protected/mysql.sock" \
-			--pid-file="$protected/mysqld.pid" &
+			--pid-file="$protected/mysqld.pid" \
+			"$MYSQLD_EXTRA_UPGRADE_OPTS" &
 
 		mysql_wait "$protected/mysql.sock" || die "MySQL didn't start, can't continue"
 
@@ -161,7 +163,8 @@ mysql_start() {
 	exec /usr/sbin/mysqld \
 		--defaults-file="$config" \
 		$ignore_db_dir \
-		--user="$mysql_daemon_user"
+		--user="$mysql_daemon_user" \
+		"$MYSQLD_EXTRA_START_OPTS"
 }
 
 # We rely on output in english at some points

--- a/common/mysql.service
+++ b/common/mysql.service
@@ -7,6 +7,7 @@ After=basic.target network.target
 [Service]
 Restart=on-failure
 Type=simple
+EnvironmentFile=-/etc/sysconfig/mysql
 ExecStartPre=/usr/lib/mysql/mysql-systemd-helper  install
 ExecStartPre=/usr/lib/mysql/mysql-systemd-helper  upgrade
 ExecStart=/usr/lib/mysql/mysql-systemd-helper     start

--- a/common/mysql.spec.in
+++ b/common/mysql.spec.in
@@ -64,6 +64,7 @@ Source15:       mysql.service
 Source16:       mysql.target
 Source17:       mysql-systemd-helper
 Source18:       mysql@.service
+Source19:       mysql.sysconfig
 BuildRequires:  bison
 BuildRequires:  cmake
 BuildRequires:  dos2unix
@@ -106,6 +107,7 @@ Requires:       %{name}-client
 Requires:       %{name}-errormessages = %{version}
 Requires:       perl-base
 Requires(pre):  pwdutils
+Requires(post): %fillup_prereq
 Recommends:     logrotate
 Conflicts:      otherproviders(mariadb-server)
 Conflicts:      otherproviders(mysql)
@@ -553,6 +555,9 @@ install -D -m 644 %{_sourcedir}/mysql@.service '%{buildroot}'%{_unitdir}/mysql@.
 install -D -m 644 %{_sourcedir}/mysql.target '%{buildroot}'%{_unitdir}/mysql.target
 rm -rf '%{buildroot}'%{_sysconfdir}/init.d
 
+# sysconfig
+install -D -m 644 %{SOURCE19} %{buildroot}%{_localstatedir}/adm/fillup-templates/sysconfig.mysql
+
 # Tmpfiles file to exclude mysql tempfiles that are auto-cleaned up
 # bnc#852451
 mkdir -p %{buildroot}%{_tmpfilesdir}
@@ -663,6 +668,7 @@ getent passwd mysql | cut -d: -f7 | grep '\b/bin/false\b' &>/dev/null || usermod
 %service_add_post mysql.service
 # Use %%tmpfiles_create when 13.2 is oldest in support scope
 %{_bindir}/systemd-tmpfiles --create %{_tmpfilesdir}/mysql.conf || :
+%{fillup_only -n mysql}
 
 # SLE11 Migration support
 for i in protected tmp; do
@@ -785,6 +791,7 @@ rm -f %{_localstatedir}/adm/update-messages/%{name}-%{version}-%{release}
 %{_datadir}/mysql/systemd/mariadb.service
 %{_datadir}/mysql/systemd/mariadb@.service
 %{_datadir}/mysql/systemd/use_galera_new_cluster.conf
+%{_localstatedir}/adm/fillup-templates/sysconfig.mysql
 %endif
 
 

--- a/common/mysql.sysconfig
+++ b/common/mysql.sysconfig
@@ -1,0 +1,24 @@
+## Path:            System/Management/Databases
+## Description:     Option to be passed to the daemon
+## ServiceReload:   mysql
+#
+## Type:            string
+## Default:         ""
+#
+# Options to pass to the daemon during startup
+#
+MYSQLD_EXTRA_START_OPTS=""
+
+## Type:            string
+## Default:         ""
+#
+# Options to pass to the daemon during install
+#
+MYSQLD_EXTRA_INSTALL_OPTS=""
+
+## Type:            string
+## Default:         ""
+#
+# Options to pass to the daemon during upgrade
+#
+MYSQLD_EXTRA_UPGRADE_OPTS=""

--- a/common/mysql@.service
+++ b/common/mysql@.service
@@ -7,6 +7,7 @@ After=basic.target network.target
 [Service]
 Restart=on-failure
 Type=simple
+EnvironmentFile=-/etc/sysconfig/mysql
 ExecStartPre=/usr/lib/mysql/mysql-systemd-helper  install %i
 ExecStartPre=/usr/lib/mysql/mysql-systemd-helper  upgrade %i
 ExecStart=/usr/lib/mysql/mysql-systemd-helper     start   %i


### PR DESCRIPTION
Add /etc/sysconfig/mysql file which can be used to pass extra arguments
to the mysqld process during startup, upgrade and install operations.