### PR TITLE
Add patch to fix crashes with GCC7

### DIFF
--- a/mariadb-101/series
+++ b/mariadb-101/series
@@ -10,3 +10,4 @@ mariadb-10.0.15-logrotate-su.patch
 mariadb-10.1.12-fortify-and-O.patch
 mariadb-10.1.16-systemd-cmake.patch
 mariadb-10.1.18-mysql_install_db-mariadb_dirs.patch
+mariadb-10.1.22-xtradb_null_checks.patch

--- a/mariadb-102/series
+++ b/mariadb-102/series
@@ -11,3 +11,4 @@ mariadb-10.1.12-fortify-and-O.patch
 mariadb-10.2.3-systemd-cmake.patch
 mariadb-10.2.3-mysql_install_db-mariadb_dirs.patch
 mariadb-10.1.20-incorrect_list_handling.patch
+mariadb-10.1.22-xtradb_null_checks.patch

--- a/patches/mysql-patches/mariadb-10.1.22-xtradb_null_checks.patch
+++ b/patches/mysql-patches/mariadb-10.1.22-xtradb_null_checks.patch
@@ -1,0 +1,21 @@
+PATCH-P1-FIX-HACK: Disable attributes globally to avoid GCC7 optimizing away null checks
+
+See boo#1041525.
+Source of this patch:
+https://jira.mariadb.org/browse/MDEV-12358?focusedCommentId=94692&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-94692
+
+Maintainer: Fabian Vogt <fvogt@suse.com>
+
+Index: mariadb-10.1.22/storage/xtradb/include/univ.i
+===================================================================
+--- mariadb-10.1.22.orig/storage/xtradb/include/univ.i
++++ mariadb-10.1.22/storage/xtradb/include/univ.i
+@@ -261,7 +261,7 @@ operations (very slow); also UNIV_DEBUG
+ that are only referenced from within InnoDB, not from MySQL. We disable the
+ GCC visibility directive on all Sun operating systems because there is no
+ easy way to get it to work. See http://bugs.mysql.com/bug.php?id=52263. */
+-#define MY_ATTRIBUTE __attribute__
++#define MY_ATTRIBUTE(X) /* empty */
+ #if defined(__GNUC__) && (__GNUC__ >= 4) && !defined(sun) || defined(__INTEL_COMPILER)
+ # define UNIV_INTERN MY_ATTRIBUTE((visibility ("hidden")))
+ #else

--- a/repack-obs-package.sh
+++ b/repack-obs-package.sh
@@ -16,7 +16,7 @@ replace_source_tarball(){
 	find . -regex '\./\(mariadb\|mysql\)-[0-9.]+\.tar\.\(xz\|gz\|bz2\)' -delete
 
     echo "Downloading the new source tarball..."
-    if `osc -A https://api.opensuse.org service localrun download_files` ; then
+    if osc -A https://api.opensuse.org service localrun download_files; then
         echo "    The new source tarball was downloaded"
     else
         echo -e "${RED}Download failed! ${NC}"


### PR DESCRIPTION
Needed in TW for a snapshot to get released.

[mariadb-101]
- Add mariadb-10.1.22-xtradb_null_checks.patch (boo#1041525)
  (See also https://jira.mariadb.org/browse/MDEV-12358)
[mariadb-102]
- Add mariadb-10.1.22-xtradb_null_checks.patch (boo#1041525)
  (See also https://jira.mariadb.org/browse/MDEV-12358)