### PR TITLE
common: Switch Restart reason to on-abort instead of on-failure

### DIFF
--- a/common/mysql.service
+++ b/common/mysql.service
@@ -5,7 +5,7 @@ Conflicts=mysql.target
 After=basic.target network.target 
 
 [Service]
-Restart=on-failure
+Restart=on-abort
 Type=simple
 ExecStartPre=/usr/lib/mysql/mysql-systemd-helper  install
 ExecStartPre=/usr/lib/mysql/mysql-systemd-helper  upgrade

--- a/common/mysql@.service
+++ b/common/mysql@.service
@@ -5,7 +5,7 @@ PartOf=mysql.target
 After=basic.target network.target
 
 [Service]
-Restart=on-failure
+Restart=on-abort
 Type=simple
 ExecStartPre=/usr/lib/mysql/mysql-systemd-helper  install %i
 ExecStartPre=/usr/lib/mysql/mysql-systemd-helper  upgrade %i


### PR DESCRIPTION
The mysql service could fail for numerous reason so restarting it
unconditionally does not necessarily mean that the problem will
automatically be fixed. Moreover, system configuration managers
may get confused when the ExecStartPost script is constantly running
and think that the entire service is active and fail to report the
mysql failure. As such, it's best to use a more conservative approach
when restarting the service using the 'on-abort' reason. This is also
similar to what the upstream service file is using.