### PR TITLE
Update MariaDB to 10.1.24

### DIFF
--- a/common/mysql.spec.in
+++ b/common/mysql.spec.in
@@ -482,7 +482,7 @@ rm -f %{buildroot}'%{_unitdir}/mariadb@bootstrap.service.d/use_galera_new_cluste
 %endif
 
 # Generate various filelists
-filelist innochecksum my_print_defaults myisam_ftdump myisamchk myisamlog myisampack mysql_fix_extensions mysql_fix_privilege_tables mysql_ssl_rsa_setup mysql_install_db mysql_secure_installation mysql_upgrade mysqlbug mysqld mysqld_multi mysqld_safe mysqlbinlog mysqldumpslow mysqlmanager mroonga resolve_stack_dump resolveip {m,}aria_chk {m,}aria_dump_log {m,}aria_ftdump {m,}aria_pack {m,}aria_read_log xtstat tokuft_logprint tokuftdump >mysql.files
+filelist galera_new_cluster galera_recovery innochecksum mariadb-service-convert my_print_defaults myisam_ftdump myisamchk myisamlog myisampack mysql_fix_extensions mysql_fix_privilege_tables mysql_ssl_rsa_setup mysql_install_db mysql_secure_installation mysql_upgrade mysqlbug mysqld mysqld_multi mysqld_safe mysqlbinlog mysqldumpslow mysqlmanager mroonga resolve_stack_dump resolveip {m,}aria_chk {m,}aria_dump_log {m,}aria_ftdump {m,}aria_pack {m,}aria_read_log xtstat tokuft_logprint tokuft_logdump tokuftdump >mysql.files
 
 filelist mysql mysqladmin mysqlcheck mysqldump mysqlimport mysqlshow mysql_config_editor mysqld_safe_helper >mysql-client.files
 # The dialog stuff is mariadb only
@@ -504,7 +504,7 @@ filelist mysqlslap >mysql-bench.files
 
 filelist mysql_client_test mysql_client_test_embedded mysql_waitpid mysqltest mysqltest_embedded >mysql-test.files
 
-filelist msql2mysql mysql_plugin mysql_convert_table_format mysql_find_rows mysql_setpermission mysql_tzinfo_to_sql mysql_zap mysqlaccess mysqlhotcopy perror replace mysql_embedded %{name}_mytop hsclient %{_bindir}/wsrep* %{_datadir}/mysql/wsrep_notify >mysql-tools.files
+filelist msql2mysql mysql_plugin mysql_convert_table_format mysql_find_rows mysql_setpermission mysql_tzinfo_to_sql mysql_zap mysqlaccess mysqlhotcopy perror replace mysql_embedded %{name}_mytop hsclient wsrep_sst_common wsrep_sst_mariabackup wsrep_sst_mysqldump wsrep_sst_rsync wsrep_sst_xtrabackup-v2 wsrep_sst_xtrabackup %{_datadir}/mysql/wsrep_notify >mysql-tools.files
 
 filelist ndbd ndbmtd ndbd_redo_log_reader >mysql-ndb-storage.files
 
@@ -773,6 +773,8 @@ rm -f %{_localstatedir}/adm/update-messages/%{name}-%{version}-%{release}
 %{_bindir}/galera_new_cluster
 %{_bindir}/galera_recovery
 %{_bindir}/mariadb-service-convert
+%{_bindir}/mariabackup
+%{_bindir}/mbstream
 %dir %{_datadir}/mysql/policy
 %dir %{_datadir}/mysql/policy/apparmor
 %{_datadir}/mysql/policy/apparmor/README
@@ -830,6 +832,9 @@ rm -f %{_localstatedir}/adm/update-messages/%{name}-%{version}-%{release}
 %files test -f mysql-test.files
 %defattr(-, root, root)
 %{_bindir}/my_safe_process
+%if "%{extra_provides}" == "mariadb_101"
+%{_mandir}/man1/my_safe_process.1*
+%endif
 %{_mandir}/man1/mysql-test-run.pl.1*
 %{_mandir}/man1/mysql-stress-test.pl.1*
 %{_datadir}/mysql-test/valgrind.supp

--- a/mariadb-101/config.yaml
+++ b/mariadb-101/config.yaml
@@ -6,7 +6,7 @@ build_readline:   1
 build_extras:     1
 extra_provides:   mariadb_101
 builtin_plugins:  partition,csv,heap,aria,pbxt,myisam,myisammrg,xtradb
-pkg-version:      "10.1.22"
+pkg-version:      "10.1.24"
 url:              "https://www.mariadb.org"
 source:           "https://downloads.mariadb.org/f/mariadb-%{version}/source/mariadb-%{version}.tar.gz"
 src-dir:          "mariadb-%{version}"

--- a/mariadb-101/series
+++ b/mariadb-101/series
@@ -10,4 +10,3 @@ mariadb-10.0.15-logrotate-su.patch
 mariadb-10.1.12-fortify-and-O.patch
 mariadb-10.1.16-systemd-cmake.patch
 mariadb-10.1.18-mysql_install_db-mariadb_dirs.patch
-mariadb-10.1.22-xtradb_null_checks.patch

--- a/mariadb-102/series
+++ b/mariadb-102/series
@@ -7,7 +7,7 @@ mysql-community-server-5.5.6-safe-process-in-bin.patch
 mariadb-10.2.3-group.patch
 mariadb-10.1.12-deharcode-libdir.patch
 mariadb-10.0.15-logrotate-su.patch
-mariadb-10.1.12-fortify-and-O.patch
+mariadb-10.2.4-fortify-and-O.patch
 mariadb-10.2.3-systemd-cmake.patch
 mariadb-10.2.3-mysql_install_db-mariadb_dirs.patch
 mariadb-10.1.20-incorrect_list_handling.patch

--- a/patches/mysql-patches/mariadb-10.2.3-mysql_install_db-mariadb_dirs.patch
+++ b/patches/mysql-patches/mariadb-10.2.3-mysql_install_db-mariadb_dirs.patch
@@ -5,11 +5,11 @@ when a user uses "--basedir" option [bsc#1006539]
 
 Maintainer: Kristyna Streitova <kstreitova@suse.com>
 
-Index: mariadb-10.2.3/scripts/mysql_install_db.sh
+Index: mariadb-10.2.4/scripts/mysql_install_db.sh
 ===================================================================
---- mariadb-10.2.3.orig/scripts/mysql_install_db.sh
-+++ mariadb-10.2.3/scripts/mysql_install_db.sh
-@@ -289,16 +289,16 @@ then
+--- mariadb-10.2.4.orig/scripts/mysql_install_db.sh
++++ mariadb-10.2.4/scripts/mysql_install_db.sh
+@@ -318,17 +318,17 @@ then
      cannot_find_file mysqld $basedir/libexec $basedir/sbin $basedir/bin
      exit 1
    fi
@@ -21,9 +21,10 @@ Index: mariadb-10.2.3/scripts/mysql_install_db.sh
 +    cannot_find_file errmsg.sys $basedir/share/english $basedir/share/mysql/english $basedir/share/mariadb/english
      exit 1
    fi
--  pkgdatadir=`find_in_basedir --dir fill_help_tables.sql share share/mysql`
-+  pkgdatadir=`find_in_basedir --dir fill_help_tables.sql share share/mysql share/mariadb`
-   if test -z "$pkgdatadir"
+-  srcpkgdatadir=`find_in_basedir --dir fill_help_tables.sql share share/mysql`
++  srcpkgdatadir=`find_in_basedir --dir fill_help_tables.sql share share/mysql share/mariadb`
+   buildpkgdatadir=$srcpkgdatadir
+   if test -z "$srcpkgdatadir"
    then
 -    cannot_find_file fill_help_tables.sql $basedir/share $basedir/share/mysql
 +    cannot_find_file fill_help_tables.sql $basedir/share $basedir/share/mysql $basedir/share/mariadb

--- a/patches/mysql-patches/mariadb-10.2.4-fortify-and-O.patch
+++ b/patches/mysql-patches/mariadb-10.2.4-fortify-and-O.patch
@@ -9,14 +9,14 @@ Index: CMakeLists.txt
 ===================================================================
 --- CMakeLists.txt.orig
 +++ CMakeLists.txt
-@@ -220,7 +220,6 @@ IF(SECURITY_HARDENED)
+@@ -218,7 +218,6 @@ IF(SECURITY_HARDENED)
    MY_CHECK_AND_SET_COMPILER_FLAG("-pie -fPIC")
    MY_CHECK_AND_SET_COMPILER_FLAG("-Wl,-z,relro,-z,now")
    MY_CHECK_AND_SET_COMPILER_FLAG("-fstack-protector --param=ssp-buffer-size=4")
 -  MY_CHECK_AND_SET_COMPILER_FLAG("-D_FORTIFY_SOURCE=2" RELEASE RELWITHDEBINFO)
  ENDIF()
  
- # Always enable debug sync for debug builds.
+ OPTION(ENABLE_DEBUG_SYNC "Enable debug sync (debug builds only)" ON) 
 Index: storage/tokudb/PerconaFT/cmake_modules/TokuSetupCompiler.cmake
 ===================================================================
 --- storage/tokudb/PerconaFT/cmake_modules/TokuSetupCompiler.cmake.orig


### PR DESCRIPTION
[mariadb-101]
- Update to MariaDB 10.1.24 GA
  * notable changes
    * XtraDB updated to 5.6.36-82.0
    * TokuDB updated to 5.6.36-82.0
    * Innodb updated to 5.6.36
    * Performance Schema updated to 5.6.36
    * MDEV-12674: Innodb_row_lock_current_waits has overflow
    * MDEV-12188: information schema - errors populating fail to free memory, unlock mutexes
    * MDEV-12832: support for streaming in tar format in MariaDB Backup has been removed
    * MDEV-6262: Fixes from coverity report on MariaDB
  * release notes and changelog:
    * https://mariadb.com/kb/en/mariadb/mariadb-10124-release-notes/
    * https://mariadb.com/kb/en/mariadb/mariadb-10124-changelog
- refresh mariadb-10.1.12-fortify-and-O.patch
- remove mariadb-10.1.22-xtradb_null_checks.patch (MDEV-12358), a fix
  was merged upstream
- Update file lists for new man-pages and tools

[mariadb-102]
- refresh and rename mariadb-10.1.12-fortify-and-O.patch to
  mariadb-10.2.4-fortify-and-O.patch
- refresh mariadb-10.2.3-mysql_install_db-mariadb_dirs.patch