### PR TITLE
Fix dependencies of "-tools" subpackage

### DIFF
--- a/common/mysql.spec.in
+++ b/common/mysql.spec.in
@@ -303,6 +303,7 @@ To run the testsuite, run %{_datadir}/mysql-test/suse-test-run.
 Summary:        %{pretty_name} tools
 Group:          Productivity/Databases/Servers
 Requires:       perl-DBD-mysql
+Requires:       socat
 Conflicts:      otherproviders(mysql-tools)
 # make sure this package is installed when updating from 10.2 and older
 Provides:       mysql-client:%{_bindir}/perror


### PR DESCRIPTION
Some scripts from the tools subpackage, namely: wsrep_sst_xtrabackup,
wsrep_sst_mariabackup.sh and wsrep_sst_xtrabackup-v2.sh need socat.